### PR TITLE
minor fix: images are no longer under js/ui/img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN cargo chef cook --release --recipe-path recipe.json
 
 FROM node:16-alpine as node_builder
 ADD --chown=node:node ./static /siwe-oidc/static
-ADD --chown=node:node ./js/ui/img /siwe-oidc/static/img
 ADD --chown=node:node ./js/ui /siwe-oidc/js/ui
 WORKDIR /siwe-oidc/js/ui
 RUN npm install


### PR DESCRIPTION
The Docker image currently fails to build for me due to this folder being missing; removing it from the Dockerfile resolves the issue