### PR TITLE
Increase default id token expiry

### DIFF
--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -282,7 +282,7 @@ pub async fn token(
     let core_id_token = CoreIdTokenClaims::new(
         IssuerUrl::from_url(base_url),
         vec![Audience::new(client_id.clone())],
-        Utc::now() + Duration::hours(2),
+        Utc::now() + Duration::hours(6),
         Utc::now(),
         resolve_claims(
             eth_provider,

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -282,7 +282,7 @@ pub async fn token(
     let core_id_token = CoreIdTokenClaims::new(
         IssuerUrl::from_url(base_url),
         vec![Audience::new(client_id.clone())],
-        Utc::now() + Duration::seconds(60),
+        Utc::now() + Duration::hours(2),
         Utc::now(),
         resolve_claims(
             eth_provider,


### PR DESCRIPTION
Close #37 

This PR changes the default ID Token expiry duration to 6 hour. The current value is 60 seconds, which is a bit too short in my opinion - asking user to sign in every 60 seconds is tough. 

In comparison, Auth0 has an [8 hour default duration](https://auth0.com/docs/secure/tokens/id-tokens#id-token-lifetime).

Feel free to reject this PR though, no pressure at all. 