### PR TITLE
Update openidconnect-rs dependency definition to point back to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,30 @@ jobs:
        include:
          - cargo_target: "x86_64-unknown-linux-gnu"
     steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: 1.67.0
+            override: true
+            components: rustfmt, clippy
       - name: Clone repo
         uses: actions/checkout@master
-      - name: Add targets
-        run: rustup target add wasm32-unknown-unknown
       - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build --verbose
         env:
           CARGO_BUILD_TARGET: ${{ matrix.cargo_target }}
-        run: cargo build --verbose
       - name: Clippy
+        uses: actions-rs/cargo@v1
         env:
           CARGO_BUILD_TARGET: ${{ matrix.cargo_target }}
-        run: RUSTFLAGS="-Dwarnings" cargo clippy
+        with:
+          command: check --verbose
       - name: Fmt
+        uses: actions-rs/cargo@v1
         env:
           CARGO_BUILD_TARGET: ${{ matrix.cargo_target }}
-        run: cargo fmt -- --check
+        with:
+          command: fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
       matrix:
        include:
          - cargo_target: "x86_64-unknown-linux-gnu"
-         - cargo_target: "wasm32-unknown-unknown"
     steps:
       - name: Clone repo
         uses: actions/checkout@master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Build and push image
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: spruceid/siwe_oidc
+        name: bounds/siwe_oidc
         username: ${{ github.actor }}
         password: ${{ secrets.GH_PACKAGE_PUSH_TOKEN }}
         registry: ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build and push image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: bounds/siwe_oidc
         username: ${{ github.actor }}
-        password: ${{ secrets.GH_PACKAGE_PUSH_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
         registry: ghcr.io
         tag_names: true
         tag_semver: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,17 +1389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint-dig"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,8 +1499,8 @@ dependencies = [
 
 [[package]]
 name = "openidconnect"
-version = "2.4.1"
-source = "git+https://github.com/sbihel/openidconnect-rs?branch=replace-ring#a1c38841e3dfb571d4fe5daece8005d2c3b73a8e"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/ramosbugs/openidconnect-rs?branch=main#9cc776c5a97fc9afe20550d7f017bd6e03b309c9"
 dependencies = [
  "base64",
  "chrono",
@@ -1479,7 +1509,6 @@ dependencies = [
  "http",
  "itertools",
  "log",
- "num-bigint",
  "oauth2",
  "p256",
  "p384",
@@ -1490,6 +1519,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
  "sha2",
  "subtle",
  "thiserror",
@@ -2225,6 +2256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,6 +2274,28 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2419,6 +2481,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ headers = "0.3.6"
 hex = "0.4.3"
 iri-string = { version = "0.6", features = ["serde"] }
 # openidconnect = "2.1.2"
-openidconnect = { git = "https://github.com/sbihel/openidconnect-rs", branch = "replace-ring", default-features = false, features = ["reqwest", "rustls-tls"] }
+openidconnect = { git = "https://github.com/ramosbugs/openidconnect-rs", branch = "main", default-features = false, features = ["reqwest", "rustls-tls"] }
 rand = "0.8.4"
 rsa = { version = "0.7.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.57.0 as chef
+FROM rust:1.67 as chef
 WORKDIR /siwe-oidc
 RUN cargo install cargo-chef
 


### PR DESCRIPTION
`replace-ring` branch was merged into openidconnect-rs

I recognize that maintainer wants to do major version bump, but this leaves the build failing until then